### PR TITLE
feat: auto-insert new cell on paste outside cells

### DIFF
--- a/js/sandbox-controller.js
+++ b/js/sandbox-controller.js
@@ -240,6 +240,25 @@ sandbox.insertCell=async function(type,after,content,output,status){
 }
 
 
+// Handle sandbox content shortcuts for paste events
+document.addEventListener('paste', (e) => {
+    // check if the paste event is happening inside an input field,
+    // textarea, or inside a CodeMirror instance
+    if (e.target.closest('input, textarea, .CodeMirror')) {
+        // If it is, let the event behave normally (do nothing here)
+        return;
+    }
+
+    // get pasted text from clipboard
+    const pastedData = e.clipboardData.getData('text');
+    
+    // insert a new cell and then set its content to the pasted data
+    sandbox.insertCell('code').then((newBlockId) => {
+        sandbox.editors[newBlockId].setValue(pastedData);
+    });
+
+    e.preventDefault();
+});
 
 
 


### PR DESCRIPTION
## Feature Description 🛠️

- as asked in this comment: https://github.com/gopi-suvanam/scribbler/pull/41#issuecomment-2600544091
- this PR adds the feature to insert a new cell and paste the copied content inside it when pressing `ctrl + v` outside the code cell.


## Video Demonstration


https://github.com/user-attachments/assets/be42ccf4-a3bc-42da-b2d8-f2c09a0aae7c




