### PR TITLE
fix :  add text colour  in css  and  margin-left in hub button list

### DIFF
--- a/components/header.html
+++ b/components/header.html
@@ -84,7 +84,7 @@
 					<summary tabindex="0" aria-haspopup="listbox" style="font-size:14px;" role="button" onclick="event.preventDefault();shareBtn()">
 				Publish</summary>
 				</li>-->
-				<li>
+				<li style="margin-left:4px;">
 					<summary tabindex="0" aria-haspopup="listbox" style="font-size:14px;" role="button" >
 					<a class="header-button" href="https://hub.scribbler.live">Hub</a></summary>
 				</li>

--- a/css/style.css
+++ b/css/style.css
@@ -250,6 +250,7 @@ input{
 	margin:0px;
 	padding:2px;
 	text-decoration: none!important;
+	color: #333;
 }
 
 @media (max-width: 600px) {
@@ -428,7 +429,7 @@ pre{
   --primary-hover: #fbc02d;
   --primary-focus: rgba(254, 222, 0,0.125);
   --primary-inverse: rgba(0, 0, 0, 0.75);
-  --font-color:#fede02
+  --font-color:#fede02;
   --secondary: #fede02;
   --form-element-background-color:white;
 


### PR DESCRIPTION


## Issue Number 🔢

 `#69`


---

## Issue Description 🛠️

In dark mode, some text elements were not displaying correctly due to missing or incorrect text color classes. Additionally, a button lacked proper spacing from adjacent elements, affecting the UI's visual balance

---
## Cause:

Dark mode styling was incomplete or inconsistent.
hub Button(in the header ) had no left margin, making it appear cramped.

## Solution in this PR:

Set the appropriate text color to fix visibility in dark mode.
I added the left margin-left to the button for better spacing and alignment.

What Problem You Solve? 💡
This PR fixes a text visibility issue in dark mode and improves the UI spacing by adjusting button margin.


## Checklist ✅

 Tested in both light and dark mode manually

 Follows style and contribution guidelines

---

## Screenshots or Video Demonstration (Optional) 📸
## Before
![Image](https://github.com/user-attachments/assets/e74cc63f-8bb4-4256-93ab-62a5323aafc3)

## After:
https://github.com/user-attachments/assets/d247cd8d-902c-4336-a4e9-ef3a83275bd7


