### PR TITLE
 fix: reduce spacing between blocks and add border to output in dark …

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -13,7 +13,7 @@
 }
 
 #main > div {
-    margin-bottom: 30px;
+    margin-bottom: 20px;
     position: relative;
 }
 
@@ -125,6 +125,8 @@ ul[role=listbox]{
 
 .output-block{
 	border-radius: 5px!important;
+    border: 1px solid #f3f1ee1e;
+
 }
 
 .CodeMirror-gutter {


### PR DESCRIPTION
Summary:
#72 

🔻 Reduced the margin between code/output blocks for a more compact layout.

🌑 Added a subtle border to output blocks in dark mode for improved visual distinction.

Why:

Improves overall layout structure and clarity.
Matches expected design feedback from issue description.



before:
![image](https://github.com/user-attachments/assets/c2305f51-313d-4a3f-a1f8-70672e7418dd)

After:
![image](https://github.com/user-attachments/assets/78289636-3e6b-4436-9d3b-bafeaa8ec4dd)


Tested:

- Verified spacing reduction between blocks.

- Dark mode border styling confirmed.

Let me know if anything else needs changing!
