### PR TITLE
Fix/modal bug

### DIFF
--- a/components/git-import-export.html
+++ b/components/git-import-export.html
@@ -28,7 +28,7 @@
 		</div>
 
 		<div class="button-row">
-			<button class="secondary" id="git-import-export" onclick="toggleModal(event)">Cancel</button>
+			<button class="secondary" data-target="git-import-export" onclick="toggleModal(event)">Cancel</button>
 			<button class="primary" onclick="upload_to_git()">Push to Git</button>
 			<button class="primary" onclick="load_from_git()">Load from Git</button>
 		</div>

--- a/components/git-import-export.html
+++ b/components/git-import-export.html
@@ -28,7 +28,7 @@
 		</div>
 
 		<div class="button-row">
-			<button class="secondary" onclick="toggleModal(event)">Cancel</button>
+			<button class="secondary" id="git-import-export" onclick="toggleModal(event)">Cancel</button>
 			<button class="primary" onclick="upload_to_git()">Push to Git</button>
 			<button class="primary" onclick="load_from_git()">Load from Git</button>
 		</div>


### PR DESCRIPTION
Addresses: issue #84 

This PR fixes the modal's Cancel button so it properly closes the GitHub integration modal.


Solution
- Added `data-target="git-import-export"` to the Cancel button so the `toggleModal` function correctly targets the modal.