### PR TITLE
feat: Add support for custom commit messages when pushing to GitHub

### DIFF
--- a/components/git-import-export.html
+++ b/components/git-import-export.html
@@ -26,6 +26,10 @@
 			<label for="path">Path</label>
 			<input type="text" id="path" placeholder="e.g., notebooks/myfile.jsnb" />
 		</div>
+		<div class="form-group">
+			<label for="path">Commit message</label>
+			<input type="text" id="commit-msg" placeholder="default: JSNB File Uploaded by User" />
+		</div>
 
 		<div class="button-row">
 			<button class="secondary" data-target="git-import-export" onclick="toggleModal(event)">Cancel</button>

--- a/js/github.js
+++ b/js/github.js
@@ -31,7 +31,7 @@ var get_file_content=async function (token,user,repo,path){
 }
 
 
-var upload_file_to_git=async function (token, content,user,repo,path) {
+var upload_file_to_git=async function (token, content,user,repo,path,commitMessage) {
 	var url=`https://api.github.com/repos/${user}/${repo}/contents/${path}`
 	let file_sha = null;
 
@@ -48,7 +48,7 @@ var upload_file_to_git=async function (token, content,user,repo,path) {
     };
 
     var data = JSON.stringify({
-        "message": "JSNB File Uploaded to Git by User",
+        "message": commitMessage,
         "content": toBase64(content),
         'sha': file_sha || undefined
     });
@@ -179,6 +179,7 @@ upload_to_git=async function(){
 	fileDetails['user']=scrib.getDom("user").value;
 	fileDetails['repo']=scrib.getDom("repo").value;
 	fileDetails['path']=scrib.getDom("path").value;
+	fileDetails['commitMessage']=scrib.getDom("commit-msg").value
 	
 	
 	// Send a message object to the iframe
@@ -186,7 +187,7 @@ upload_to_git=async function(){
       	
 	const content=JSON.stringify(nb,undefined,2);
 	try{
-		const upload_status= await upload_file_to_git(fileDetails['token'],content,fileDetails['user'],fileDetails['repo'],fileDetails['path']);
+		const upload_status= await upload_file_to_git(fileDetails['token'],content,fileDetails['user'],fileDetails['repo'],fileDetails['path'],fileDetails['commitMessage']||"JSNB File Uploaded by User");
 		alert("Successfully pushed");
 		closeModal(scrib.getDom('git-import-export'));
 		const nextURL = `./?jsnb=github:${fileDetails['user']}/${fileDetails['repo']}/${fileDetails['path']}`;


### PR DESCRIPTION
## Issue Number 🔢

This pull request addresses, issue #88 


## Issue Description 🛠️

When pushing a notebook to GitHub from Scribbler using a personal access token, there's currently no option to specify a custom commit message. As a result, every push creates a commit with the same default message, which clutters the commit history and makes it difficult to track specific changes or improvements over time.


## Summary of the Change

This PR introduces a new input field in the GitHub export modal that allows users to enter a custom commit message when pushing their notebooks. If no message is provided, it falls back to a default message: `JSNB File Uploaded by User`.


## How to Test

1. Go to the GitHub export section in https://parthsidpara.github.io/scribbler/
2. Enter a personal access token, repo details, and a custom commit message.
3. Push changes and verify that the commit appears on GitHub with the correct message.
4. Try leaving the commit message field empty and ensure the default message is used.