### PR TITLE
feat: Add OpenAI API support to AI models (part of #100)

### DIFF
--- a/js/ai-coder.js
+++ b/js/ai-coder.js
@@ -8,7 +8,8 @@ aiConfig={
 		//"OpenVino":"OpenVino"
 	},
 	apis:{
-		"Google AI Studio":"google-ai-studio"
+		"Google AI Studio":"google-ai-studio",
+		"OpenAI":"openai"
 	}
 }
 

--- a/js/api-wrapper.js
+++ b/js/api-wrapper.js
@@ -26,11 +26,36 @@ APIWrapper.call = async function(source,key,params){
 		if("error" in result) return result.error.message;	
 		else return result.candidates[0].content.parts.map(part=>part.text).join("\n");	
 	}
+	if(source==='openai'){
+		if(typeof(key)=='undefined') throw("Couldn't find the OpenAI API key");
+		const url = 'https://api.openai.com/v1/chat/completions';
+		const data = {
+		  "model": "gpt-3.5-turbo",
+		  "messages": [
+			{
+			  "role": "user",
+			  "content": params.prompt
+			}
+		  ],
+		  "max_tokens": 2000,
+		  "temperature": 0.7
+		};
+		const response = await fetch(url, {
+		  method: 'POST',
+		  headers: {
+			'Content-Type': 'application/json',
+			'Authorization': `Bearer ${key}`
+		  },
+		  body: JSON.stringify(data)
+		});
+
+		const result= await response.json();
+		if("error" in result) return result.error.message;	
+		else return result.choices[0].message.content;	
+	}
 	if(source=='OpenVino'){
 		const url = 'http://localhost:5000/generate';
 
-
-		
 		// Make the POST request
 		const response = await fetch(url, {
 		    method: 'POST', // Use POST instead of GET

--- a/secrets.html
+++ b/secrets.html
@@ -59,9 +59,15 @@
 			<hr>
 			<h3>API Keys</h3>
 			<h4>Google AI Studio</h4>
-			<input type="password" id="google-ai-studio-key" onchange="setAPIKey('google-ai-studio',document.getElementById('google-ai-studio-key').value)" placeholder="api-key"></input>
+			<input type="password" id="google-ai-studio-key" onchange="setAPIKey('google-ai-studio',document.getElementById('google-ai-studio-key').value)" placeholder="gemini-key"></input>
 			<a href='https://aistudio.google.com/app/apikey' target='_blank'>Link for getting Google AI Studio API Key</a>
 			<p>This will be used for AI and will be sent to Google APIs</p>
+			
+			<h4>OpenAI</h4>
+			<input type="password" id="openai-key" onchange="setAPIKey('openai',document.getElementById('openai-key').value)" placeholder="openai-key"></input>
+			<a href='https://platform.openai.com/api-keys' target='_blank'>Link for getting OpenAI API Key</a>
+			<p>This will be used for AI and will be sent to OpenAI APIs</p>
+			
 			<form onsubmit="storeSecret(event)">
 				<h3>New Secret</h3>
 				<p style="color:green">None of the secrets will be shared with Scribbler or other servers unless explicity sent by a notebook.</p>


### PR DESCRIPTION
## 🚀 Feature: Add OpenAI API Support to Scribbler

### Description
This implements **OpenAI (ChatGPT) API integration** as part of the AI features enhancement requested in issue #100. Users can now select OpenAI as their AI provider alongside the existing Google AI Studio and local models.

### 🎯 What's Implemented

- ✅ **OpenAI API Integration**: Added support for GPT-3.5-turbo model
- ✅ **UI Integration**: OpenAI appears in the AI dropdown menu
- ✅ **API Key Management**: Secure local storage of OpenAI API keys
- ✅ **Error Handling**: Proper error messages for API failures


The AI will generate code and explanations using OpenAI's GPT-3.5-turbo model.

### 🚧 Next Steps

1. Add Claude (Anthropic) API support
2. Add Grok API support and other models.



https://github.com/user-attachments/assets/18ddf62e-af62-4b4a-8acd-9d8f0a52a750


