### PR TITLE
upgraded the model from gemini-1.5-flash-latest to gemini-2.5-flash and its corresponding url

### DIFF
--- a/js/api-wrapper.js
+++ b/js/api-wrapper.js
@@ -3,8 +3,8 @@ APIWrapper={};
 // API Provider Configurations
 APIWrapper.providers = {
 	'google-ai-studio': {
-		url: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent',
-		model: 'gemini-1.5-flash-latest',
+		url: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent',
+		model: 'gemini-2.5-flash',
 		authType: 'query', // API key in query parameter
 		requestFormat: 'google',
 		responseFormat: 'google'


### PR DESCRIPTION

### Pull Request Template

this pull request addresses #121 
---

## Issue Description 🛠️

the ai coding and chatbot where not working with gemini api key due to the use of depreciated model use

I have provided the latest model of gemini which would work perfectly
---

## Checklist ✅

---

## Screenshots or Video Demonstration (Optional) 📸


| **Earlier Output**  | **Current Output**  |
<img width="807" height="1179" alt="image" src="https://github.com/user-attachments/assets/7a67e095-79a3-4a29-84e4-e4b4e2c3bf85" />
<img width="804" height="1183" alt="image" src="https://github.com/user-attachments/assets/fdc53db6-90ba-4da3-a5d5-24fab9daa893" />


<img width="2801" height="409" alt="image" src="https://github.com/user-attachments/assets/7797b321-ee54-47f0-bfb5-d0c35f97ba44" />
<img width="2828" height="1307" alt="image" src="https://github.com/user-attachments/assets/3c2c6dbf-0196-4f71-838a-44279c351946" />

